### PR TITLE
FEAT dont use seller id by default

### DIFF
--- a/lib/alipay/service.rb
+++ b/lib/alipay/service.rb
@@ -12,7 +12,7 @@ module Alipay
         'service'        => 'create_partner_trade_by_buyer',
         '_input_charset' => 'utf-8',
         'partner'        => options[:pid] || Alipay.pid,
-        'seller_id'      => options[:pid] || Alipay.pid,
+        # 'seller_id'      => options[:pid] || Alipay.pid,
         'payment_type'   => '1'
       }.merge(params)
 


### PR DESCRIPTION
平台担保交易需要设置seller_email, 默认优先级低于seller_id，因此去除了默认的seller_id
